### PR TITLE
Remove requirements for nightly features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,3 @@ bindgen = "0.43"
 fs_extra = "1.1"
 num_cpus = "1.8"
 target-lexicon = "0.2"
-
-[target.'cfg(target_env = "msvc")'.build-dependencies]
-vswhere = "0.1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+
+os: Visual Studio 2015
+
+environment:
+  matrix:
+    - channel: nightly
+      target: x86_64-pc-windows-msvc
+
+# Install the rust target and channel defined by the 
+# configuration matrix.
+install:
+  - git submodule update --init
+  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init -yv --default-toolchain %channel% --default-host %target%
+  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - rustc -vV
+  - cargo -vV
+
+build: false
+
+test_script:
+  - cargo test --verbose

--- a/src/c2rust.rs
+++ b/src/c2rust.rs
@@ -6,7 +6,6 @@ mod libc {
 
 use crate::xed_interface::*;
 
-
 pub unsafe extern "C" fn xed_make_uint64(mut hi: u32, mut lo: u32) -> u64 {
     let mut y: xed_union64_t = xed_union64_t { byte: [0; 8] };
     y.s.lo32 = lo;
@@ -240,10 +239,7 @@ pub unsafe extern "C" fn xed3_operand_get_uimm1(mut d: *const xed_decoded_inst_t
     return (*d)._operands.uimm1;
 }
 
-pub unsafe extern "C" fn xed3_operand_set_uimm1(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: u8,
-) {
+pub unsafe extern "C" fn xed3_operand_set_uimm1(mut d: *mut xed_decoded_inst_t, mut opval: u8) {
     (*d)._operands.uimm1 = opval;
 }
 
@@ -251,10 +247,7 @@ pub unsafe extern "C" fn xed3_operand_get_uimm0(mut d: *const xed_decoded_inst_t
     return (*d)._operands.uimm0;
 }
 
-pub unsafe extern "C" fn xed3_operand_set_uimm0(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: u64,
-) {
+pub unsafe extern "C" fn xed3_operand_set_uimm0(mut d: *mut xed_decoded_inst_t, mut opval: u64) {
     (*d)._operands.uimm0 = opval;
 }
 
@@ -632,10 +625,7 @@ pub unsafe extern "C" fn xed3_operand_get_imm_width(mut d: *const xed_decoded_in
     return (*d)._operands.imm_width;
 }
 
-pub unsafe extern "C" fn xed3_operand_set_imm_width(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: u8,
-) {
+pub unsafe extern "C" fn xed3_operand_set_imm_width(mut d: *mut xed_decoded_inst_t, mut opval: u8) {
     (*d)._operands.imm_width = opval;
 }
 
@@ -1080,9 +1070,7 @@ pub unsafe extern "C" fn xed3_operand_set_mem0(
     (*d)._operands.mem0 = opval as u8;
 }
 
-pub unsafe extern "C" fn xed3_operand_get_brdisp_width(
-    mut d: *const xed_decoded_inst_t,
-) -> u8 {
+pub unsafe extern "C" fn xed3_operand_get_brdisp_width(mut d: *const xed_decoded_inst_t) -> u8 {
     return (*d)._operands.brdisp_width;
 }
 // / @name Exceptions
@@ -1830,10 +1818,7 @@ pub unsafe extern "C" fn xed_reg(mut reg: xed_reg_enum_t) -> xed_encoder_operand
     return o;
 }
 
-pub unsafe extern "C" fn xed_imm0(
-    mut v: u64,
-    mut width_bits: xed_uint_t,
-) -> xed_encoder_operand_t {
+pub unsafe extern "C" fn xed_imm0(mut v: u64, mut width_bits: xed_uint_t) -> xed_encoder_operand_t {
     let mut o: xed_encoder_operand_t = xed_encoder_operand_t {
         type_: XED_ENCODER_OPERAND_TYPE_INVALID,
         u: xed_encoder_operand_t__bindgen_ty_1 {
@@ -2406,9 +2391,7 @@ pub unsafe extern "C" fn xed_decoded_inst_get_second_immediate(
     return xed3_operand_get_uimm1(p);
 }
 
-pub unsafe extern "C" fn xed_decoded_inst_get_user_data(
-    mut p: *mut xed_decoded_inst_t,
-) -> u64 {
+pub unsafe extern "C" fn xed_decoded_inst_get_user_data(mut p: *mut xed_decoded_inst_t) -> u64 {
     return (*p).u.user_data;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 //! Note that `xed_tables_init()` must be called before
 //! using the library.
 
-#![feature(extern_types)]
-
 #![allow(
     non_snake_case,
     dead_code,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
     no_mangle_const_items,
     non_upper_case_globals,
     unreachable_code,
-    intra_doc_link_resolution_failure,
+    intra_doc_link_resolution_failure
 )]
 
 extern crate core;
@@ -32,8 +32,8 @@ mod xed_interface_inner {
 }
 
 pub mod xed_interface {
-    pub use crate::xed_interface_inner::*;
     pub use crate::c2rust::*;
+    pub use crate::xed_interface_inner::*;
 }
 
 pub mod xed_version {


### PR DESCRIPTION
This bundles up two changes
- Remove `#[feature(extern_types)]` which should allow everything to compile on stable
- Format the c2rust translations of certain xed functions