### PR TITLE
Add basic appveyor configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,3 @@ bindgen = "0.43"
 fs_extra = "1.1"
 num_cpus = "1.8"
 target-lexicon = "0.2"
-
-[target.'cfg(target_env = "msvc")'.build-dependencies]
-vswhere = "0.1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ environment:
 # Install the rust target and channel defined by the 
 # configuration matrix.
 install:
+  - git submodule update --init
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %target%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+
+os: Visual Studio 2015
+
+environment:
+  matrix:
+    - channel: nightly
+      target: x86_64-pc-windows-msvc
+
+# Install the rust target and channel defined by the 
+# configuration matrix.
+install:
+  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init -yv --default-toolchain %channel% --default-host %target%
+  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - rustc -vV
+  - cargo -vV
+
+build: false
+
+test_script:
+  - cargo test --verbose


### PR DESCRIPTION
This adds a really simple appveyor configuration and fixes the build script to work on windows from within a MSVC dev tools shell environment.

In the future I'd like to remove this restriction (i.e. have the build script search for and run the vcvarsxx.bat) but that looks like it would be quite a lot of work and not necessary for an MVP.