### PR TITLE
Set locale to C

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -175,6 +175,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         ::std::process::exit(1);
     }
 
+    // Set locale to C to avoid user language setting interference
+    env::set_var("LC_ALL", "C");
+
     // Build the project
     let output = Command::new("python").arg("mfile.py")
         .arg(format!("--jobs={}", num_cpus::get()))


### PR DESCRIPTION
If the user's locale setting is some language which contains non ASCII character, then `mfile.py` will fail. E.g. on my machine where the locale is `fr_FR.UTF-8`, then `mfile.py` fails:

```bash
--- stdout
cargo:rerun-if-changed=build.rs
Failed to run `mfile.py`
	Exit Code: 1
	StdErr:
 
	StdOut:
 [PYTHON VERSION] 2.7.16
========
git description stdout:
'ascii' codec can't encode character u'\xe9' in position 24: ordinal not in range(128)
```

that is because the script parses the following error string:

```bash
git description stdout:
fatal: ce n'est pas un dépôt git : /var/tmp/xed-sys2/target/debug/build/xed-sys2-d8d21d9ddac74212/out/xed/../.git/modules/xed
```
where, for example, `é` is not a valid ASCII.

The PR simply sets the locale to `C` before running `mfile.py`.
