### PR TITLE
Improve build scripts

### DIFF
--- a/build-tools/src/bin/build-xed.rs
+++ b/build-tools/src/bin/build-xed.rs
@@ -2,7 +2,10 @@ use std::{
     env, fs, io,
     path::{Path, PathBuf},
     process::Command,
+    str::FromStr,
 };
+
+use target_lexicon::Triple;
 
 fn create_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
     fs::create_dir(path).or_else(|e| match e.kind() {
@@ -11,22 +14,27 @@ fn create_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
     })
 }
 
+fn find_python() -> &'static str {
+    if let Ok(status) = Command::new("python3").arg("-V").status() {
+        if status.success() {
+            return "python3";
+        }
+    }
+
+    if let Ok(status) = Command::new("python").arg("-V").status() {
+        if status.success() {
+            return "python";
+        }
+    }
+
+    panic!("Unable to find a working python installation");
+}
+
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("Failed to read OUT_DIR"));
     let cwd = env::current_dir().expect("Failed to get CWD");
+    let target = env::var("TARGET").expect("Failed to read TARGET");
     let profile = env::var("PROFILE").unwrap_or_else(|_| "debug".to_owned());
-
-    // Ensure python exists and can run
-    match Command::new("python").arg("-V").output() {
-        Ok(output) => {
-            if !output.status.success() {
-                panic!("'python -V' returned with an error");
-            }
-        }
-        Err(e) => {
-            panic!("Python is required to run xed: {}", e);
-        }
-    }
 
     let install_dir = out_dir.join("install");
     let build_dir = out_dir.join("build");
@@ -47,18 +55,29 @@ fn main() {
     env::set_current_dir(&build_dir).unwrap();
 
     let num_jobs: u32 = env::var("NUM_JOBS")
-        .unwrap_or("1".to_owned())
+        .unwrap_or_else(|_| "1".to_owned())
         .parse()
         .unwrap_or(1);
 
-    let mut cmd = Command::new("python");
-    cmd.arg(&mfile_path)
+    let python = find_python();
+    let mut cmd = Command::new(python);
+    cmd
+        // The -B flag prevents python from generating .pyc files
+        .arg("-B")
+        .arg(&mfile_path)
         .arg(format!("--jobs={}", num_jobs))
         .arg("--silent")
         .arg("--static-stripped")
         .arg("--extra-ccflags=-fPIC")
         .arg("--no-werror")
-        .arg(format!("--install-dir={}", install_dir.display()));
+        .arg(format!(
+            "--host-cpu={}",
+            Triple::from_str(&target)
+                .expect("TARGET was not a valid target triple")
+                .architecture
+        ))
+        .arg(format!("--install-dir={}", install_dir.display()))
+        .env("PYTHONDONTWRITEBYTECODE", "x");
 
     if profile == "release" {
         cmd.arg("--opt=3");
@@ -68,9 +87,13 @@ fn main() {
 
     cmd.arg("install").current_dir(&build_dir);
 
+    eprintln!("XED build command: {:?}", cmd);
+
     let status = cmd.status().expect("Failed to start xed build");
 
     if !status.success() {
         panic!("Building xed failed");
     }
+
+    let lib_dir = install_dir.join("lib");
 }

--- a/build.rs
+++ b/build.rs
@@ -37,12 +37,10 @@ fn build_bindings(cwd: &Path) {
         .derive_copy(true)
         .derive_debug(true)
         .prepend_enum_name(false);
-    
+
     builder.dump_preprocessed_input().unwrap();
 
-    let bindings = match builder
-        .generate()
-    {
+    let bindings = match builder.generate() {
         Ok(x) => x,
         Err(e) => panic!(
             "Could not generate bindings for {}. Error {:?}",
@@ -62,19 +60,15 @@ fn build_bindings(cwd: &Path) {
 
 fn find_python() -> &'static str {
     if let Ok(status) = Command::new("python3").arg("-V").status() {
-        if !status.success() {
-            panic!("'python3 -V' exited with an error");
+        if status.success() {
+            return "python3";
         }
-
-        return "python3";
     }
 
     if let Ok(status) = Command::new("python").arg("-V").status() {
-        if !status.success() {
-            panic!("'python -V' exited with an error");
+        if status.success() {
+            return "python";
         }
-
-        return "python";
     }
 
     panic!("Unable to find a working python installation");
@@ -91,18 +85,6 @@ fn main() {
     let cwd = env::current_dir().expect("Failed to get CWD");
     let target = env::var("TARGET").expect("Failed to read TARGET");
     let profile = env::var("PROFILE").unwrap_or_else(|_| "debug".to_owned());
-
-    // Ensure python exists and can run
-    match Command::new("python").arg("-V").output() {
-        Ok(output) => {
-            if !output.status.success() {
-                panic!("'python -V' returned with an error");
-            }
-        }
-        Err(e) => {
-            panic!("Python is required to run xed: {}", e);
-        }
-    }
 
     let install_dir = out_dir.join("install");
     let build_dir = out_dir.join("build");

--- a/build.rs
+++ b/build.rs
@@ -71,7 +71,7 @@ fn find_python() -> &'static str {
         }
     }
 
-    panic!("Unable to find a working python installation");
+    panic!("Unable to find a working python installation. Tried `python3` and `python`.");
 }
 
 fn main() {

--- a/tests/functions-exist.rs
+++ b/tests/functions-exist.rs
@@ -1,0 +1,9 @@
+use xed_sys::xed_interface::*;
+
+#[test]
+fn functions_exist() {
+    unsafe {
+        // Just ensuring that this compiles
+        let _ = xed_isa_set_is_valid_for_chip(XED_ISA_SET_AES, XED_CHIP_AMD);
+    }
+}

--- a/xed.h
+++ b/xed.h
@@ -1,0 +1,2 @@
+#include "xed/xed-interface.h"
+#include "xed/xed-isa-set.h"


### PR DESCRIPTION
This is a few small changes to make the build scripts work better in more-broken-than-usual environments. 

Specifically, ones where `python3` or `python` exists but isn't actually a valid python executable. This happens on Windows 10 when the user hasn't installed python from the windows store.

