### PR TITLE
Update XED version to v11.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xed-sys"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["Phantomical", "Agustin Godnic"]
 license = "Apache-2.0"
 description = "Rust FFI bindings for Intel XED."
@@ -13,7 +13,6 @@ categories = ["encoding", "external-ffi-bindings", "hardware-support", "parsing"
 [badges]
 appveyor  = { repository = "rust-xed/xed-sys" }
 travis-ci = { repository = "rust-xed/xed-sys" }
-
 
 [dependencies]
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ install:
   - rustc -vV
   - cargo -vV
   - rustup component add clippy
+  - py -0p
 
 build: false
 

--- a/build-tools/build-c2rust-bindings
+++ b/build-tools/build-c2rust-bindings
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 export RUST_BACKTRACE=1
-export PYTHONDONTWRITEBYTECODE=x
 
 mkdir -p target/artifacts
 OUT_DIR=$(pwd)/target cargo run --bin build-xed

--- a/build-tools/build-c2rust-bindings
+++ b/build-tools/build-c2rust-bindings
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export RUST_BACKTRACE=1
+export PYTHONDONTWRITEBYTECODE=x
 
 mkdir -p target/artifacts
 OUT_DIR=$(pwd)/target cargo run --bin build-xed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,8 @@ mod _detail {
             clippy::all,
             non_camel_case_types,
             non_snake_case,
-            non_upper_case_globals
+            non_upper_case_globals,
+            intra_doc_link_resolution_failure
         )]
 
         include!(concat!(env!("OUT_DIR"), "/xed_interface.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! Note that [`xed_tables_init()`][0] must be called before
 //! using the library.
-//! 
+//!
 //! [0]: crate::xed_tables_init
 
 extern crate core;
@@ -38,9 +38,9 @@ mod _detail {
             clippy::all,
             dead_code,
             non_camel_case_types,
-            unused_variables, 
-            unused_assignments, 
-            unused_mut,
+            unused_variables,
+            unused_assignments,
+            unused_mut
         )]
 
         use super::libc;
@@ -48,7 +48,7 @@ mod _detail {
 
         // The c2rust conversion produces code that uses these,
         // luckily binding them manually is pretty easy.
-        // 
+        //
         // Some of these are never used but we keep them to that
         // we don't have to make any changes if a future version
         // of XED requires them.
@@ -78,7 +78,7 @@ mod _detail {
             clippy::all,
             non_camel_case_types,
             non_snake_case,
-            non_upper_case_globals,
+            non_upper_case_globals
         )]
 
         include!(concat!(env!("OUT_DIR"), "/xed_interface.rs"));
@@ -97,7 +97,7 @@ mod _detail {
             };
 
             assert_eq!(
-                "Copyright (C) 2017, Intel Corporation. All rights reserved.",
+                "Copyright (C) 2019, Intel Corporation. All rights reserved.",
                 &copyright
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,24 +2,10 @@
 //!
 //! For the real docs see: https://intelxed.github.io
 //!
-//! Note that `xed_tables_init()` must be called before
+//! Note that [`xed_tables_init()`][0] must be called before
 //! using the library.
-
-#![allow(
-    non_snake_case,
-    dead_code,
-    non_camel_case_types,
-    const_err,
-    improper_ctypes,
-    path_statements,
-    unused_parens,
-    unused_unsafe,
-    no_mangle_const_items,
-    non_upper_case_globals,
-    unreachable_code,
-    intra_doc_link_resolution_failure,
-    clippy::all
-)]
+//! 
+//! [0]: crate::xed_tables_init
 
 extern crate core;
 
@@ -48,13 +34,24 @@ mod _detail {
     }
 
     pub(crate) mod c2rust {
-        #![allow(unused_variables, unused_assignments, unused_mut)]
+        #![allow(
+            clippy::all,
+            dead_code,
+            non_camel_case_types,
+            unused_variables, 
+            unused_assignments, 
+            unused_mut,
+        )]
 
         use super::libc;
         use super::xed_interface_inner::*;
 
         // The c2rust conversion produces code that uses these,
         // luckily binding them manually is pretty easy.
+        // 
+        // Some of these are never used but we keep them to that
+        // we don't have to make any changes if a future version
+        // of XED requires them.
         type uint8_t = u8;
         type uint16_t = u16;
         type uint32_t = u32;
@@ -71,10 +68,19 @@ mod _detail {
         // with a new version of XED.
         type C2RustUnnamed_6 = xed_encoder_operand_t__bindgen_ty_1;
 
+        // Note: Can't use a module here since we need to insert
+        //       types into the namespace of the generated code.
         include!("xed-c2rust.rs");
     }
 
     pub(crate) mod xed_interface_inner {
+        #![allow(
+            clippy::all,
+            non_camel_case_types,
+            non_snake_case,
+            non_upper_case_globals,
+        )]
+
         include!(concat!(env!("OUT_DIR"), "/xed_interface.rs"));
     }
 

--- a/src/xed-c2rust.rs
+++ b/src/xed-c2rust.rs
@@ -1376,17 +1376,6 @@ pub unsafe extern "C" fn xed3_operand_set_vl(
     (*d)._operands.vl = opval as uint8_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_vlx(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.vlx as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_vlx(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.vlx = opval as uint8_t;
-}
-#[inline]
 pub unsafe extern "C" fn xed3_operand_get_vex_prefix(
     mut d: *const xed_decoded_inst_t,
 ) -> xed_bits_t {

--- a/src/xed-c2rust.rs
+++ b/src/xed-c2rust.rs
@@ -129,32 +129,62 @@ pub unsafe extern "C" fn xed_inst_exception(mut p: *const xed_inst_t) -> xed_exc
     return (*p)._exceptions as xed_exception_enum_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed_flag_set_mask(mut p: *const xed_flag_set_t) -> libc::c_int {
-    return (*p).flat as libc::c_int;
+pub unsafe extern "C" fn xed_flag_set_mask(mut p: *const xed_flag_set_t) -> libc::c_uint {
+    return (*p).flat;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_sib(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.sib as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_seg_ovd(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.seg_ovd as xed_bits_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_sib(
+pub unsafe extern "C" fn xed3_operand_set_seg_ovd(
     mut d: *mut xed_decoded_inst_t,
     mut opval: xed_bits_t,
 ) {
-    (*d)._operands.sib = opval as uint8_t;
+    (*d)._operands.seg_ovd = opval as uint8_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_last_f2f3(
+pub unsafe extern "C" fn xed3_operand_get_hint(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.hint as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_hint(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.hint = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_lock(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.lock as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_lock(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.lock = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_need_memdisp(
     mut d: *const xed_decoded_inst_t,
 ) -> xed_bits_t {
-    return (*d)._operands.last_f2f3 as xed_bits_t;
+    return (*d)._operands.need_memdisp as xed_bits_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_last_f2f3(
+pub unsafe extern "C" fn xed3_operand_set_need_memdisp(
     mut d: *mut xed_decoded_inst_t,
     mut opval: xed_bits_t,
 ) {
-    (*d)._operands.last_f2f3 = opval as uint8_t;
+    (*d)._operands.need_memdisp = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_disp(mut d: *const xed_decoded_inst_t) -> int64_t {
+    return (*d)._operands.disp as int64_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_disp(mut d: *mut xed_decoded_inst_t, mut opval: int64_t) {
+    (*d)._operands.disp = opval as uint64_t;
 }
 #[inline]
 pub unsafe extern "C" fn xed3_operand_get_disp_width(mut d: *const xed_decoded_inst_t) -> uint8_t {
@@ -166,6 +196,410 @@ pub unsafe extern "C" fn xed3_operand_set_disp_width(
     mut opval: uint8_t,
 ) {
     (*d)._operands.disp_width = opval;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_brdisp_width(
+    mut d: *const xed_decoded_inst_t,
+) -> uint8_t {
+    return (*d)._operands.brdisp_width;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_brdisp_width(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: uint8_t,
+) {
+    (*d)._operands.brdisp_width = opval;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_df32(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.df32 as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_df32(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.df32 = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_df64(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.df64 as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_df64(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.df64 = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_norex(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.norex as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_norex(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.norex = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_needrex(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.needrex as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_needrex(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.needrex = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_rex(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.rex as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_rex(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.rex = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_rexw(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.rexw as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_rexw(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.rexw = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_rexr(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.rexr as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_rexr(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.rexr = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_rexx(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.rexx as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_rexx(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.rexx = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_rexb(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.rexb as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_rexb(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.rexb = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_rep(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.rep as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_rep(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.rep = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_osz(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.osz as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_osz(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.osz = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_prefix66(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.prefix66 as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_prefix66(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.prefix66 = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_asz(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.asz as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_asz(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.asz = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_eosz(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.eosz as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_eosz(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.eosz = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_easz(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.easz as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_easz(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.easz = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_mod(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.mod_ as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_mod(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.mod_ = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_reg(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.reg as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_reg(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.reg = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_srm(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.srm as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_srm(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.srm = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_rm(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.rm as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_rm(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.rm = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_realmode(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.realmode as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_realmode(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.realmode = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_chip(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_chip_enum_t {
+    return (*d)._operands.chip as xed_chip_enum_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_chip(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_chip_enum_t,
+) {
+    (*d)._operands.chip = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_mode(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.mode as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_mode(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.mode = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_smode(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.smode as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_smode(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.smode = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_modep5(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.modep5 as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_modep5(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.modep5 = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_modep55c(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.modep55c as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_modep55c(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.modep55c = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_p4(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.p4 as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_p4(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.p4 = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_lzcnt(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.lzcnt as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_lzcnt(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.lzcnt = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_tzcnt(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.tzcnt as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_tzcnt(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.tzcnt = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_mode_first_prefix(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.mode_first_prefix as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_mode_first_prefix(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.mode_first_prefix = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_imm0(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.imm0 as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_imm0(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.imm0 = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_imm1(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.imm1 as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_imm1(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.imm1 = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_imm0signed(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.imm0signed as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_imm0signed(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.imm0signed = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_uimm0(mut d: *const xed_decoded_inst_t) -> uint64_t {
+    return (*d)._operands.uimm0;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_uimm0(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: uint64_t,
+) {
+    (*d)._operands.uimm0 = opval;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_uimm1(mut d: *const xed_decoded_inst_t) -> uint8_t {
+    return (*d)._operands.uimm1;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_uimm1(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: uint8_t,
+) {
+    (*d)._operands.uimm1 = opval;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_imm_width(mut d: *const xed_decoded_inst_t) -> uint8_t {
+    return (*d)._operands.imm_width;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_imm_width(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: uint8_t,
+) {
+    (*d)._operands.imm_width = opval;
 }
 #[inline]
 pub unsafe extern "C" fn xed3_operand_get_using_default_segment0(
@@ -194,164 +628,17 @@ pub unsafe extern "C" fn xed3_operand_set_using_default_segment1(
     (*d)._operands.using_default_segment1 = opval as uint8_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_hint(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.hint as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_hint(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.hint = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_sae(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.sae as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_sae(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.sae = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_mode_first_prefix(
+pub unsafe extern "C" fn xed3_operand_get_default_seg(
     mut d: *const xed_decoded_inst_t,
 ) -> xed_bits_t {
-    return (*d)._operands.mode_first_prefix as xed_bits_t;
+    return (*d)._operands.default_seg as xed_bits_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_mode_first_prefix(
+pub unsafe extern "C" fn xed3_operand_set_default_seg(
     mut d: *mut xed_decoded_inst_t,
     mut opval: xed_bits_t,
 ) {
-    (*d)._operands.mode_first_prefix = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_uimm1(mut d: *const xed_decoded_inst_t) -> uint8_t {
-    return (*d)._operands.uimm1;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_uimm1(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: uint8_t,
-) {
-    (*d)._operands.uimm1 = opval;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_uimm0(mut d: *const xed_decoded_inst_t) -> uint64_t {
-    return (*d)._operands.uimm0;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_uimm0(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: uint64_t,
-) {
-    (*d)._operands.uimm0 = opval;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_smode(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.smode as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_smode(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.smode = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_rm(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.rm as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_rm(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.rm = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_chip(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_chip_enum_t {
-    return (*d)._operands.chip as xed_chip_enum_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_chip(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_chip_enum_t,
-) {
-    (*d)._operands.chip = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_amd3dnow(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.amd3dnow as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_amd3dnow(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.amd3dnow = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_map(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.map as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_map(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.map = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_sibindex(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.sibindex as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_sibindex(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.sibindex = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_agen(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.agen as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_agen(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.agen = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_nominal_opcode(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_bits_t {
-    return (*d)._operands.nominal_opcode as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_nominal_opcode(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.nominal_opcode = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_seg1(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
-    return (*d)._operands.seg1 as xed_reg_enum_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_seg1(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_reg_enum_t,
-) {
-    (*d)._operands.seg1 = opval as uint16_t;
+    (*d)._operands.default_seg = opval as uint8_t;
 }
 #[inline]
 pub unsafe extern "C" fn xed3_operand_get_seg0(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
@@ -365,28 +652,17 @@ pub unsafe extern "C" fn xed3_operand_set_seg0(
     (*d)._operands.seg0 = opval as uint16_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_cldemote(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.cldemote as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_cldemote(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.cldemote = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_nprefixes(
+pub unsafe extern "C" fn xed3_operand_get_base0(
     mut d: *const xed_decoded_inst_t,
-) -> xed_bits_t {
-    return (*d)._operands.nprefixes as xed_bits_t;
+) -> xed_reg_enum_t {
+    return (*d)._operands.base0 as xed_reg_enum_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_nprefixes(
+pub unsafe extern "C" fn xed3_operand_set_base0(
     mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
+    mut opval: xed_reg_enum_t,
 ) {
-    (*d)._operands.nprefixes = opval as uint8_t;
+    (*d)._operands.base0 = opval as uint16_t;
 }
 #[inline]
 pub unsafe extern "C" fn xed3_operand_get_index(
@@ -402,17 +678,6 @@ pub unsafe extern "C" fn xed3_operand_set_index(
     (*d)._operands.index = opval as uint16_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_ild_f2(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.ild_f2 as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_ild_f2(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.ild_f2 = opval as uint8_t;
-}
-#[inline]
 pub unsafe extern "C" fn xed3_operand_get_scale(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
     return (*d)._operands.scale as xed_bits_t;
 }
@@ -424,151 +689,127 @@ pub unsafe extern "C" fn xed3_operand_set_scale(
     (*d)._operands.scale = opval as uint8_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_llrc(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.llrc as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_sib(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.sib as xed_bits_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_llrc(
+pub unsafe extern "C" fn xed3_operand_set_sib(
     mut d: *mut xed_decoded_inst_t,
     mut opval: xed_bits_t,
 ) {
-    (*d)._operands.llrc = opval as uint8_t;
+    (*d)._operands.sib = opval as uint8_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_esrc(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.esrc as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_sibscale(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.sibscale as xed_bits_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_esrc(
+pub unsafe extern "C" fn xed3_operand_set_sibscale(
     mut d: *mut xed_decoded_inst_t,
     mut opval: xed_bits_t,
 ) {
-    (*d)._operands.esrc = opval as uint8_t;
+    (*d)._operands.sibscale = opval as uint8_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_nrexes(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.nrexes as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_sibbase(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.sibbase as xed_bits_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_nrexes(
+pub unsafe extern "C" fn xed3_operand_set_sibbase(
     mut d: *mut xed_decoded_inst_t,
     mut opval: xed_bits_t,
 ) {
-    (*d)._operands.nrexes = opval as uint8_t;
+    (*d)._operands.sibbase = opval as uint8_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_pos_sib(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.pos_sib as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_sibindex(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.sibindex as xed_bits_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_pos_sib(
+pub unsafe extern "C" fn xed3_operand_set_sibindex(
     mut d: *mut xed_decoded_inst_t,
     mut opval: xed_bits_t,
 ) {
-    (*d)._operands.pos_sib = opval as uint8_t;
+    (*d)._operands.sibindex = opval as uint8_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_osz(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.osz as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_seg1(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
+    return (*d)._operands.seg1 as xed_reg_enum_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_osz(
+pub unsafe extern "C" fn xed3_operand_set_seg1(
     mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
+    mut opval: xed_reg_enum_t,
 ) {
-    (*d)._operands.osz = opval as uint8_t;
+    (*d)._operands.seg1 = opval as uint16_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_has_sib(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.has_sib as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_has_sib(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.has_sib = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_eosz(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.eosz as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_eosz(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.eosz = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_element_size(
+pub unsafe extern "C" fn xed3_operand_get_base1(
     mut d: *const xed_decoded_inst_t,
-) -> xed_bits_t {
-    return (*d)._operands.element_size as xed_bits_t;
+) -> xed_reg_enum_t {
+    return (*d)._operands.base1 as xed_reg_enum_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_element_size(
+pub unsafe extern "C" fn xed3_operand_set_base1(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_reg_enum_t,
+) {
+    (*d)._operands.base1 = opval as uint16_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_mem0(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.mem0 as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_mem0(
     mut d: *mut xed_decoded_inst_t,
     mut opval: xed_bits_t,
 ) {
-    (*d)._operands.element_size = opval as uint16_t;
+    (*d)._operands.mem0 = opval as uint8_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_pos_disp(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.pos_disp as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_mem1(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.mem1 as xed_bits_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_pos_disp(
+pub unsafe extern "C" fn xed3_operand_set_mem1(
     mut d: *mut xed_decoded_inst_t,
     mut opval: xed_bits_t,
 ) {
-    (*d)._operands.pos_disp = opval as uint8_t;
+    (*d)._operands.mem1 = opval as uint8_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_ubit(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.ubit as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_mem_width(mut d: *const xed_decoded_inst_t) -> uint16_t {
+    return (*d)._operands.mem_width;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_ubit(
+pub unsafe extern "C" fn xed3_operand_set_mem_width(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: uint16_t,
+) {
+    (*d)._operands.mem_width = opval;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_agen(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.agen as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_agen(
     mut d: *mut xed_decoded_inst_t,
     mut opval: xed_bits_t,
 ) {
-    (*d)._operands.ubit = opval as uint8_t;
+    (*d)._operands.agen = opval as uint8_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_vexdest210(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_bits_t {
-    return (*d)._operands.vexdest210 as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_relbr(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.relbr as xed_bits_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_vexdest210(
+pub unsafe extern "C" fn xed3_operand_set_relbr(
     mut d: *mut xed_decoded_inst_t,
     mut opval: xed_bits_t,
 ) {
-    (*d)._operands.vexdest210 = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_vexdest3(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.vexdest3 as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_vexdest3(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.vexdest3 = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_cet(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.cet as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_cet(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.cet = opval as uint8_t;
+    (*d)._operands.relbr = opval as uint8_t;
 }
 #[inline]
 pub unsafe extern "C" fn xed3_operand_get_ptr(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
@@ -580,177 +821,6 @@ pub unsafe extern "C" fn xed3_operand_set_ptr(
     mut opval: xed_bits_t,
 ) {
     (*d)._operands.ptr = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_p4(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.p4 as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_p4(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.p4 = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_modep55c(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.modep55c as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_modep55c(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.modep55c = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_iclass(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_iclass_enum_t {
-    return (*d)._operands.iclass as xed_iclass_enum_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_iclass(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_iclass_enum_t,
-) {
-    (*d)._operands.iclass = opval as uint16_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_imm_width(mut d: *const xed_decoded_inst_t) -> uint8_t {
-    return (*d)._operands.imm_width;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_imm_width(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: uint8_t,
-) {
-    (*d)._operands.imm_width = opval;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_bcrc(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.bcrc as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_bcrc(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.bcrc = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_error(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_error_enum_t {
-    return (*d)._operands.error as xed_error_enum_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_error(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_error_enum_t,
-) {
-    (*d)._operands.error = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_nelem(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.nelem as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_nelem(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.nelem = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_imm0signed(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_bits_t {
-    return (*d)._operands.imm0signed as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_imm0signed(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.imm0signed = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_reg8(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
-    return (*d)._operands.reg8 as xed_reg_enum_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_reg8(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_reg_enum_t,
-) {
-    (*d)._operands.reg8 = opval as uint16_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_reg6(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
-    return (*d)._operands.reg6 as xed_reg_enum_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_reg6(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_reg_enum_t,
-) {
-    (*d)._operands.reg6 = opval as uint16_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_reg7(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
-    return (*d)._operands.reg7 as xed_reg_enum_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_reg7(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_reg_enum_t,
-) {
-    (*d)._operands.reg7 = opval as uint16_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_reg4(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
-    return (*d)._operands.reg4 as xed_reg_enum_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_reg4(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_reg_enum_t,
-) {
-    (*d)._operands.reg4 = opval as uint16_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_reg5(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
-    return (*d)._operands.reg5 as xed_reg_enum_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_reg5(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_reg_enum_t,
-) {
-    (*d)._operands.reg5 = opval as uint16_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_reg2(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
-    return (*d)._operands.reg2 as xed_reg_enum_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_reg2(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_reg_enum_t,
-) {
-    (*d)._operands.reg2 = opval as uint16_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_reg3(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
-    return (*d)._operands.reg3 as xed_reg_enum_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_reg3(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_reg_enum_t,
-) {
-    (*d)._operands.reg3 = opval as uint16_t;
 }
 #[inline]
 pub unsafe extern "C" fn xed3_operand_get_reg0(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
@@ -775,409 +845,81 @@ pub unsafe extern "C" fn xed3_operand_set_reg1(
     (*d)._operands.reg1 = opval as uint16_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_ild_seg(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.ild_seg as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_reg2(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
+    return (*d)._operands.reg2 as xed_reg_enum_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_ild_seg(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.ild_seg = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_base1(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_reg_enum_t {
-    return (*d)._operands.base1 as xed_reg_enum_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_base1(
+pub unsafe extern "C" fn xed3_operand_set_reg2(
     mut d: *mut xed_decoded_inst_t,
     mut opval: xed_reg_enum_t,
 ) {
-    (*d)._operands.base1 = opval as uint16_t;
+    (*d)._operands.reg2 = opval as uint16_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_mod(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.mod_ as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_reg3(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
+    return (*d)._operands.reg3 as xed_reg_enum_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_mod(
+pub unsafe extern "C" fn xed3_operand_set_reg3(
     mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
+    mut opval: xed_reg_enum_t,
 ) {
-    (*d)._operands.mod_ = opval as uint8_t;
+    (*d)._operands.reg3 = opval as uint16_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_disp(mut d: *const xed_decoded_inst_t) -> int64_t {
-    return (*d)._operands.disp as int64_t;
+pub unsafe extern "C" fn xed3_operand_get_reg4(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
+    return (*d)._operands.reg4 as xed_reg_enum_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_disp(mut d: *mut xed_decoded_inst_t, mut opval: int64_t) {
-    (*d)._operands.disp = opval as uint64_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_rex(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.rex as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_rex(
+pub unsafe extern "C" fn xed3_operand_set_reg4(
     mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
+    mut opval: xed_reg_enum_t,
 ) {
-    (*d)._operands.rex = opval as uint8_t;
+    (*d)._operands.reg4 = opval as uint16_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_rexb(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.rexb as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_reg5(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
+    return (*d)._operands.reg5 as xed_reg_enum_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_rexb(
+pub unsafe extern "C" fn xed3_operand_set_reg5(
     mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
+    mut opval: xed_reg_enum_t,
 ) {
-    (*d)._operands.rexb = opval as uint8_t;
+    (*d)._operands.reg5 = opval as uint16_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_pos_imm(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.pos_imm as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_reg6(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
+    return (*d)._operands.reg6 as xed_reg_enum_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_pos_imm(
+pub unsafe extern "C" fn xed3_operand_set_reg6(
     mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
+    mut opval: xed_reg_enum_t,
 ) {
-    (*d)._operands.pos_imm = opval as uint8_t;
+    (*d)._operands.reg6 = opval as uint16_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_rep(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.rep as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_reg7(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
+    return (*d)._operands.reg7 as xed_reg_enum_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_rep(
+pub unsafe extern "C" fn xed3_operand_set_reg7(
     mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
+    mut opval: xed_reg_enum_t,
 ) {
-    (*d)._operands.rep = opval as uint8_t;
+    (*d)._operands.reg7 = opval as uint16_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_rexw(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.rexw as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_reg8(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
+    return (*d)._operands.reg8 as xed_reg_enum_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_rexw(
+pub unsafe extern "C" fn xed3_operand_set_reg8(
     mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
+    mut opval: xed_reg_enum_t,
 ) {
-    (*d)._operands.rexw = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_ild_f3(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.ild_f3 as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_ild_f3(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.ild_f3 = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_rexr(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.rexr as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_rexr(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.rexr = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_encoder_preferred(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_bits_t {
-    return (*d)._operands.encoder_preferred as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_encoder_preferred(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.encoder_preferred = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_reg(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.reg as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_reg(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.reg = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_pos_nominal_opcode(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_bits_t {
-    return (*d)._operands.pos_nominal_opcode as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_pos_nominal_opcode(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.pos_nominal_opcode = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_rexx(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.rexx as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_rexx(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.rexx = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_prefix66(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.prefix66 as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_prefix66(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.prefix66 = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_rexrr(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.rexrr as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_rexrr(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.rexrr = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_asz(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.asz as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_asz(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.asz = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_mask(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.mask as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_mask(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.mask = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_mem1(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.mem1 as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_mem1(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.mem1 = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_easz(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.easz as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_easz(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.easz = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_pos_imm1(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.pos_imm1 as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_pos_imm1(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.pos_imm1 = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_mem_width(mut d: *const xed_decoded_inst_t) -> uint16_t {
-    return (*d)._operands.mem_width;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_mem_width(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: uint16_t,
-) {
-    (*d)._operands.mem_width = opval;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_lzcnt(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.lzcnt as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_lzcnt(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.lzcnt = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_mem0(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.mem0 as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_mem0(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.mem0 = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_brdisp_width(
-    mut d: *const xed_decoded_inst_t,
-) -> uint8_t {
-    return (*d)._operands.brdisp_width;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_brdisp_width(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: uint8_t,
-) {
-    (*d)._operands.brdisp_width = opval;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_imm1_bytes(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_bits_t {
-    return (*d)._operands.imm1_bytes as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_imm1_bytes(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.imm1_bytes = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_tzcnt(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.tzcnt as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_tzcnt(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.tzcnt = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_df64(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.df64 as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_df64(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.df64 = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_lock(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.lock as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_lock(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.lock = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_has_modrm(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_bits_t {
-    return (*d)._operands.has_modrm as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_has_modrm(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.has_modrm = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_zeroing(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.zeroing as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_zeroing(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.zeroing = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_srm(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.srm as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_srm(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.srm = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_vexvalid(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.vexvalid as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_vexvalid(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.vexvalid = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_needrex(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.needrex as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_needrex(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.needrex = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_skip_osz(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.skip_osz as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_skip_osz(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.skip_osz = opval as uint8_t;
+    (*d)._operands.reg8 = opval as uint16_t;
 }
 #[inline]
 pub unsafe extern "C" fn xed3_operand_get_outreg(
@@ -1193,146 +935,78 @@ pub unsafe extern "C" fn xed3_operand_set_outreg(
     (*d)._operands.outreg = opval as uint16_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_default_seg(
+pub unsafe extern "C" fn xed3_operand_get_encoder_preferred(
     mut d: *const xed_decoded_inst_t,
 ) -> xed_bits_t {
-    return (*d)._operands.default_seg as xed_bits_t;
+    return (*d)._operands.encoder_preferred as xed_bits_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_default_seg(
+pub unsafe extern "C" fn xed3_operand_set_encoder_preferred(
     mut d: *mut xed_decoded_inst_t,
     mut opval: xed_bits_t,
 ) {
-    (*d)._operands.default_seg = opval as uint8_t;
+    (*d)._operands.encoder_preferred = opval as uint8_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_nseg_prefixes(
+pub unsafe extern "C" fn xed3_operand_get_error(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_error_enum_t {
+    return (*d)._operands.error as xed_error_enum_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_error(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_error_enum_t,
+) {
+    (*d)._operands.error = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_iclass(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_iclass_enum_t {
+    return (*d)._operands.iclass as xed_iclass_enum_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_iclass(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_iclass_enum_t,
+) {
+    (*d)._operands.iclass = opval as uint16_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_nelem(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.nelem as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_nelem(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.nelem = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_element_size(
     mut d: *const xed_decoded_inst_t,
 ) -> xed_bits_t {
-    return (*d)._operands.nseg_prefixes as xed_bits_t;
+    return (*d)._operands.element_size as xed_bits_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_nseg_prefixes(
+pub unsafe extern "C" fn xed3_operand_set_element_size(
     mut d: *mut xed_decoded_inst_t,
     mut opval: xed_bits_t,
 ) {
-    (*d)._operands.nseg_prefixes = opval as uint8_t;
+    (*d)._operands.element_size = opval as uint16_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_vex_c4(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.vex_c4 as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_map(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.map as xed_bits_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_vex_c4(
+pub unsafe extern "C" fn xed3_operand_set_map(
     mut d: *mut xed_decoded_inst_t,
     mut opval: xed_bits_t,
 ) {
-    (*d)._operands.vex_c4 = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_pos_modrm(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_bits_t {
-    return (*d)._operands.pos_modrm as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_pos_modrm(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.pos_modrm = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_bcast(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.bcast as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_bcast(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.bcast = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_seg_ovd(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.seg_ovd as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_seg_ovd(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.seg_ovd = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_vex_prefix(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_bits_t {
-    return (*d)._operands.vex_prefix as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_vex_prefix(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.vex_prefix = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_dummy(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.dummy as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_dummy(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.dummy = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_norex(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.norex as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_norex(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.norex = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_roundc(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.roundc as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_roundc(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.roundc = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_sibbase(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.sibbase as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_sibbase(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.sibbase = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_need_memdisp(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_bits_t {
-    return (*d)._operands.need_memdisp as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_need_memdisp(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.need_memdisp = opval as uint8_t;
+    (*d)._operands.map = opval as uint8_t;
 }
 #[inline]
 pub unsafe extern "C" fn xed3_operand_get_out_of_bytes(
@@ -1348,177 +1022,15 @@ pub unsafe extern "C" fn xed3_operand_set_out_of_bytes(
     (*d)._operands.out_of_bytes = opval as uint8_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_imm1(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.imm1 as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_amd3dnow(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.amd3dnow as xed_bits_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_imm1(
+pub unsafe extern "C" fn xed3_operand_set_amd3dnow(
     mut d: *mut xed_decoded_inst_t,
     mut opval: xed_bits_t,
 ) {
-    (*d)._operands.imm1 = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_imm0(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.imm0 as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_imm0(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.imm0 = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_no_scale_disp8(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_bits_t {
-    return (*d)._operands.no_scale_disp8 as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_no_scale_disp8(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.no_scale_disp8 = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_relbr(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.relbr as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_relbr(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.relbr = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_base0(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_reg_enum_t {
-    return (*d)._operands.base0 as xed_reg_enum_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_base0(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_reg_enum_t,
-) {
-    (*d)._operands.base0 = opval as uint16_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_df32(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.df32 as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_df32(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.df32 = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_realmode(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.realmode as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_realmode(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.realmode = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_modrm_byte(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_bits_t {
-    return (*d)._operands.modrm_byte as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_modrm_byte(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.modrm_byte = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_mode(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.mode as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_mode(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.mode = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_mpxmode(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.mpxmode as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_mpxmode(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.mpxmode = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_sibscale(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.sibscale as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_sibscale(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.sibscale = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_vl(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.vl as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_vl(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.vl = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_wbnoinvd(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.wbnoinvd as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_wbnoinvd(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.wbnoinvd = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_max_bytes(
-    mut d: *const xed_decoded_inst_t,
-) -> xed_bits_t {
-    return (*d)._operands.max_bytes as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_max_bytes(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.max_bytes = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_modep5(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.modep5 as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_modep5(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.modep5 = opval as uint8_t;
+    (*d)._operands.amd3dnow = opval as uint8_t;
 }
 #[inline]
 pub unsafe extern "C" fn xed3_operand_get_first_f2f3(
@@ -1534,6 +1046,439 @@ pub unsafe extern "C" fn xed3_operand_set_first_f2f3(
     (*d)._operands.first_f2f3 = opval as uint8_t;
 }
 #[inline]
+pub unsafe extern "C" fn xed3_operand_get_last_f2f3(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.last_f2f3 as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_last_f2f3(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.last_f2f3 = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_ild_f2(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.ild_f2 as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_ild_f2(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.ild_f2 = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_ild_f3(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.ild_f3 as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_ild_f3(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.ild_f3 = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_max_bytes(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.max_bytes as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_max_bytes(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.max_bytes = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_ild_seg(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.ild_seg as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_ild_seg(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.ild_seg = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_nseg_prefixes(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.nseg_prefixes as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_nseg_prefixes(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.nseg_prefixes = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_nrexes(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.nrexes as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_nrexes(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.nrexes = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_nprefixes(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.nprefixes as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_nprefixes(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.nprefixes = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_nominal_opcode(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.nominal_opcode as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_nominal_opcode(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.nominal_opcode = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_pos_nominal_opcode(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.pos_nominal_opcode as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_pos_nominal_opcode(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.pos_nominal_opcode = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_has_modrm(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.has_modrm as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_has_modrm(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.has_modrm = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_has_sib(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.has_sib as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_has_sib(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.has_sib = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_pos_modrm(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.pos_modrm as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_pos_modrm(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.pos_modrm = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_pos_sib(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.pos_sib as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_pos_sib(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.pos_sib = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_pos_disp(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.pos_disp as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_pos_disp(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.pos_disp = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_pos_imm(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.pos_imm as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_pos_imm(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.pos_imm = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_pos_imm1(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.pos_imm1 as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_pos_imm1(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.pos_imm1 = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_imm1_bytes(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.imm1_bytes as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_imm1_bytes(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.imm1_bytes = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_modrm_byte(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.modrm_byte as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_modrm_byte(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.modrm_byte = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_esrc(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.esrc as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_esrc(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.esrc = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_vexvalid(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.vexvalid as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_vexvalid(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.vexvalid = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_dummy(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.dummy as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_dummy(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.dummy = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_mpxmode(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.mpxmode as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_mpxmode(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.mpxmode = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_cet(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.cet as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_cet(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.cet = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_cldemote(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.cldemote as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_cldemote(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.cldemote = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_vexdest3(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.vexdest3 as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_vexdest3(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.vexdest3 = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_vexdest210(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.vexdest210 as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_vexdest210(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.vexdest210 = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_vl(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.vl as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_vl(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.vl = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_vlx(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.vlx as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_vlx(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.vlx = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_vex_prefix(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.vex_prefix as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_vex_prefix(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.vex_prefix = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_vex_c4(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.vex_c4 as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_vex_c4(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.vex_c4 = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_bcast(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.bcast as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_bcast(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.bcast = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_must_use_evex(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.must_use_evex as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_must_use_evex(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.must_use_evex = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_zeroing(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.zeroing as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_zeroing(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.zeroing = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_llrc(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.llrc as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_llrc(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.llrc = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_bcrc(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.bcrc as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_bcrc(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.bcrc = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_rexrr(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.rexrr as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_rexrr(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.rexrr = opval as uint8_t;
+}
+#[inline]
 pub unsafe extern "C" fn xed3_operand_get_vexdest4(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
     return (*d)._operands.vexdest4 as xed_bits_t;
 }
@@ -1543,6 +1488,74 @@ pub unsafe extern "C" fn xed3_operand_set_vexdest4(
     mut opval: xed_bits_t,
 ) {
     (*d)._operands.vexdest4 = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_mask(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.mask as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_mask(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.mask = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_roundc(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.roundc as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_roundc(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.roundc = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_sae(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.sae as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_sae(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.sae = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_no_scale_disp8(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.no_scale_disp8 as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_no_scale_disp8(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.no_scale_disp8 = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_ubit(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.ubit as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_ubit(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.ubit = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_wbnoinvd(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.wbnoinvd as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_wbnoinvd(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.wbnoinvd = opval as uint8_t;
 }
 #[inline]
 pub unsafe extern "C" fn xed_state_init(
@@ -1582,9 +1595,10 @@ pub unsafe extern "C" fn xed_state_long64_mode(mut p: *const xed_state_t) -> xed
 }
 #[inline]
 pub unsafe extern "C" fn xed_state_real_mode(mut p: *const xed_state_t) -> xed_bool_t {
-    return (xed_state_get_machine_mode(p) as libc::c_uint
-        == XED_MACHINE_MODE_REAL_16 as libc::c_int as libc::c_uint) as libc::c_int
-        as xed_bool_t;
+    let mut mmode: xed_machine_mode_enum_t = xed_state_get_machine_mode(p);
+    return (mmode as libc::c_uint == XED_MACHINE_MODE_REAL_16 as libc::c_int as libc::c_uint
+        || mmode as libc::c_uint == XED_MACHINE_MODE_REAL_32 as libc::c_int as libc::c_uint)
+        as libc::c_int as xed_bool_t;
 }
 #[inline]
 pub unsafe extern "C" fn xed_state_mode_width_16(mut p: *const xed_state_t) -> xed_bool_t {
@@ -1615,7 +1629,7 @@ pub unsafe extern "C" fn xed_state_get_address_width(
 ) -> xed_address_width_enum_t {
     match xed_state_get_machine_mode(p) as libc::c_uint {
         1 => return XED_ADDRESS_WIDTH_64b,
-        6 => return XED_ADDRESS_WIDTH_32b,
+        6 | 7 => return XED_ADDRESS_WIDTH_32b,
         4 | 2 => return XED_ADDRESS_WIDTH_32b,
         5 | 3 => return XED_ADDRESS_WIDTH_16b,
         _ => return XED_ADDRESS_WIDTH_INVALID,
@@ -1654,7 +1668,7 @@ pub unsafe extern "C" fn xed_encoder_request_operands(
 }
 #[inline]
 pub unsafe extern "C" fn xed_disp(
-    mut displacement: uint64_t,
+    mut displacement: int64_t,
     mut displacement_bits: uint32_t,
 ) -> xed_enc_displacement_t {
     let mut x: xed_enc_displacement_t = xed_enc_displacement_t {
@@ -1743,7 +1757,7 @@ pub unsafe extern "C" fn xed_simm0(
         width_bits: 0,
     };
     o.type_ = XED_ENCODER_OPERAND_TYPE_SIMM0;
-    o.u.imm0 = v as uint64_t;
+    o.u.imm0 = xed_sign_extend32_64(v) as uint64_t;
     o.width_bits = width_bits;
     return o;
 }
@@ -1822,7 +1836,7 @@ pub unsafe extern "C" fn xed_mem_b(
     o.u.mem.seg = XED_REG_INVALID;
     o.u.mem.index = XED_REG_INVALID;
     o.u.mem.scale = 0i32 as uint32_t;
-    o.u.mem.disp.displacement = 0i32 as uint64_t;
+    o.u.mem.disp.displacement = 0i32 as int64_t;
     o.u.mem.disp.displacement_bits = 0i32 as uint32_t;
     o.width_bits = width_bits;
     return o;
@@ -1891,7 +1905,7 @@ pub unsafe extern "C" fn xed_mem_gb(
     o.u.mem.seg = seg;
     o.u.mem.index = XED_REG_INVALID;
     o.u.mem.scale = 0i32 as uint32_t;
-    o.u.mem.disp.displacement = 0i32 as uint64_t;
+    o.u.mem.disp.displacement = 0i32 as int64_t;
     o.u.mem.disp.displacement_bits = 0i32 as uint32_t;
     o.width_bits = width_bits;
     return o;
@@ -2202,11 +2216,11 @@ pub unsafe extern "C" fn xed_decoded_inst_get_byte(
 pub unsafe extern "C" fn xed_decoded_inst_get_machine_mode_bits(
     mut p: *const xed_decoded_inst_t,
 ) -> xed_uint_t {
-    let mut mode: uint8_t = xed3_operand_get_mode(p) as uint8_t;
-    if mode as libc::c_int == 2i32 {
+    let mut mode: xed_uint_t = xed3_operand_get_mode(p);
+    if mode == 2i32 as libc::c_uint {
         return 64i32 as xed_uint_t;
     }
-    if mode as libc::c_int == 1i32 {
+    if mode == 1i32 as libc::c_uint {
         return 32i32 as xed_uint_t;
     }
     return 16i32 as xed_uint_t;
@@ -2215,11 +2229,11 @@ pub unsafe extern "C" fn xed_decoded_inst_get_machine_mode_bits(
 pub unsafe extern "C" fn xed_decoded_inst_get_stack_address_mode_bits(
     mut p: *const xed_decoded_inst_t,
 ) -> xed_uint_t {
-    let mut smode: uint8_t = xed3_operand_get_smode(p) as uint8_t;
-    if smode as libc::c_int == 2i32 {
+    let mut smode: xed_uint_t = xed3_operand_get_smode(p);
+    if smode == 2i32 as libc::c_uint {
         return 64i32 as xed_uint_t;
     }
-    if smode as libc::c_int == 1i32 {
+    if smode == 1i32 as libc::c_uint {
         return 32i32 as xed_uint_t;
     }
     return 16i32 as xed_uint_t;

--- a/tests/functions-exist.rs
+++ b/tests/functions-exist.rs
@@ -1,0 +1,9 @@
+use xed_sys::xed_interface::*;
+
+#[test]
+fn functions_exist() {
+    unsafe {
+        // Just ensuring that this compiles
+        let _ = xed_isa_set_is_valid_for_chip(XED_ISA_SET_AES, XED_CHIP_AMD);
+    }
+}

--- a/xed.h
+++ b/xed.h
@@ -1,0 +1,2 @@
+#include "xed/xed-interface.h"
+#include "xed/xed-isa-set.h"


### PR DESCRIPTION
This PR updates the bundled version of XED to the latest version. This is a non-backwards compatible change as XED itself underwent non-backwards compatible changes during this time.

This PR seems pretty big but most of it is autogenerated code.

