### PR TITLE
Update bindgen to version 0.55

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "rust-xed/xed-sys" }
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.54"
+bindgen = "0.55"
 target-lexicon = "0.11"
 
 [workspace]

--- a/build-tools/Cargo.toml
+++ b/build-tools/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Phantomical", "Agustin Godnic"]
 edition = "2018"
 
 [dependencies]
-bindgen = "0.54"
-fs_extra = "1.1"
-num_cpus = "1.10"
+bindgen = "0.55"
+fs_extra = "1.2"
+num_cpus = "1.13"
 target-lexicon = "0.11"
 
 syn = { version = "1.0", features = [ "full" ] }

--- a/build-tools/build-c2rust-bindings
+++ b/build-tools/build-c2rust-bindings
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 
-export RUST_BACKTRACE=1
-
-mkdir -p target/artifacts
-OUT_DIR=$(pwd)/target cargo run --bin build-xed
-
 # Every architecture I've tried has given the same result
 # here so either clang's preprocessor ignores target when
 # preprocessing or the generated code is target-independant
 # (at least from a source-code point of view)
 triple=x86_64-unknown-unknown
+
+export RUST_BACKTRACE=1
+export TARGET=$triple
+
+mkdir -p target/artifacts
+OUT_DIR=$(pwd)/target cargo run --bin build-xed
 
 clang -E -P -CC xed.c -o target/artifacts/xed-$triple.i -Itarget/install/include -Dstatic= -Dinline= -D__inline= -D__inline__=
 
@@ -27,8 +28,8 @@ rustfmt target/xed-$triple.rs
 # statements here.
 sed 's/type_0/type_/g' -i target/xed-$triple.rs
 sed 's/mod_0/mod_/g' -i target/xed-$triple.rs
-sed 's/i64_0/i64/g' -i target/xed-$triple.rs
-sed 's/u64_0/u64/g' -i target/xed-$triple.rs
+sed 's/i64_0/i64_/g' -i target/xed-$triple.rs
+sed 's/u64_0/u64_/g' -i target/xed-$triple.rs
 
 cp -f target/xed-$triple.rs ../src/xed-c2rust.rs
 

--- a/build.rs
+++ b/build.rs
@@ -70,7 +70,7 @@ fn find_python() -> Command {
             return cmd;
         }
     }
-    
+
     // Next check for an explicit python3 installation.
     if let Ok(status) = Command::new("python3").arg("-V").status() {
         if status.success() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ mod _detail {
             non_camel_case_types,
             non_snake_case,
             non_upper_case_globals,
-            intra_doc_link_resolution_failure
+            broken_intra_doc_links
         )]
 
         include!(concat!(env!("OUT_DIR"), "/xed_interface.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ mod _detail {
             non_camel_case_types,
             non_snake_case,
             non_upper_case_globals,
-            broken_intra_doc_links
+            intra_doc_link_resolution_failure
         )]
 
         include!(concat!(env!("OUT_DIR"), "/xed_interface.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ mod _detail {
             non_camel_case_types,
             non_snake_case,
             non_upper_case_globals,
+            renamed_and_removed_lints, // needed for intra_doc_link_resolution_failure
             intra_doc_link_resolution_failure
         )]
 

--- a/src/xed-c2rust.rs
+++ b/src/xed-c2rust.rs
@@ -3,14 +3,14 @@ pub unsafe extern "C" fn xed_make_uint64(mut hi: uint32_t, mut lo: uint32_t) -> 
     let mut y: xed_union64_t = xed_union64_t { byte: [0; 8] };
     y.s.lo32 = lo;
     y.s.hi32 = hi;
-    return y.u64;
+    return y.u64_;
 }
 #[inline]
 pub unsafe extern "C" fn xed_make_int64(mut hi: uint32_t, mut lo: uint32_t) -> int64_t {
     let mut y: xed_union64_t = xed_union64_t { byte: [0; 8] };
     y.s.lo32 = lo;
     y.s.hi32 = hi;
-    return y.i64;
+    return y.i64_;
 }
 #[inline]
 pub unsafe extern "C" fn xed_iform_to_iclass(mut iform: xed_iform_enum_t) -> xed_iclass_enum_t {


### PR DESCRIPTION
This version of bindgen had a change in the way that it outputs union fields with names of builtin types (a field named u64 is now named u64_) so this change also updates the c2rust build scripts to take that into account.

As I was fixing up the build scripts I also updated them to fix some issues that I hit while trying to get them to work.

Closes #36 as well.