### PR TITLE
Allow xed-sys to build with python 3.9

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/intelxed/xed
 [submodule "mbuild"]
 	path = mbuild
-	url = https://github.com/intelxed/mbuild
+	url = https://github.com/rust-xed/mbuild

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xed-sys"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Phantomical", "Agustin Godnic"]
 license = "Apache-2.0"
 description = "Rust FFI bindings for Intel XED."


### PR DESCRIPTION
Basically, python 3.9 changed some stuff that caused mbuild to break. This PR works around the issue by using our own fork of mbuild that includes the fix by @rocallahan. I've tested this locally using a 3.9 docker image and can verify both the failure and that the fix works when building xed-sys.

Once this gets fixed upstream (either in mbuild or in python proper) we can revert this change and go back to normal.