### PR TITLE
Update xed to latest upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/intelxed/xed
 [submodule "mbuild"]
 	path = mbuild
-	url = https://github.com/rust-xed/mbuild
+	url = https://github.com/intelxed/mbuild

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/intelxed/xed
 [submodule "mbuild"]
 	path = mbuild
-	url = https://github.com/intelxed/mbuild
+	url = https://github.com/rust-xed/mbuild

--- a/build-tools/build-c2rust-bindings
+++ b/build-tools/build-c2rust-bindings
@@ -12,9 +12,16 @@ export TARGET=$triple
 mkdir -p target/artifacts
 OUT_DIR=$(pwd)/target cargo run --bin build-xed
 
-clang -E -P -CC xed.c -o target/artifacts/xed-$triple.i -Itarget/install/include -Dstatic= -Dinline= -D__inline= -D__inline__=
+clang -E -P -CC xed.c -o target/artifacts/xed-$triple.c -Itarget/install/include -Dstatic= -Dinline= -D__inline= -D__inline__=
 
-echo '[{ "directory": ".", "command": "", "file": "target/artifacts/xed-'$triple'.i" }]' > compile-commands.json
+(
+  echo "[{"
+  echo '"directory": "'$(pwd)'",'
+  echo "\"command\": \"clang -c target/artifacts/xed-'$triple'.c -o target/artifacts/xed-$triple.o \","
+  echo '"file": "target/artifacts/xed-'$triple'.c"'
+  echo "}]"
+) > compile-commands.json
+# echo '[{ "directory": ".", "command": "clang -c xed.c -o target/artifacts/xed-$triple.o  -Itarget/install/include -Dstatic= -Dinline= -D__inline= -D__inline__=", "file": "xed.c" }]' > compile_commands.json
 c2rust transpile --overwrite-existing compile-commands.json
 
 lower_triple=$(echo $triple | sed 's/-/_/g')

--- a/build.rs
+++ b/build.rs
@@ -107,14 +107,10 @@ fn main() {
     let build_dir = out_dir.join("build");
     let mfile_path = cwd.join("xed/mfile.py");
 
-    create_dir(&install_dir).unwrap_or_else(|_| panic!(
-        "Failed to create directory '{}'",
-        install_dir.display()
-    ));
-    create_dir(&build_dir).unwrap_or_else(|_| panic!(
-        "Failed to create directory '{}'",
-        build_dir.display()
-    ));
+    create_dir(&install_dir)
+        .unwrap_or_else(|_| panic!("Failed to create directory '{}'", install_dir.display()));
+    create_dir(&build_dir)
+        .unwrap_or_else(|_| panic!("Failed to create directory '{}'", build_dir.display()));
 
     // Set locale to C to avoid user language settings interference
     env::set_var("LC_ALL", "C");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ mod _detail {
         // conventions between c2rust and bindgen.
         // This should break pretty loudly if it becomes wrong
         // with a new version of XED.
-        type C2RustUnnamed_6 = xed_encoder_operand_t__bindgen_ty_1;
+        type C2RustUnnamed_7 = xed_encoder_operand_t__bindgen_ty_1;
 
         // Note: Can't use a module here since we need to insert
         //       types into the namespace of the generated code.
@@ -99,7 +99,7 @@ mod _detail {
             };
 
             assert_eq!(
-                "Copyright (C) 2019, Intel Corporation. All rights reserved.",
+                "Copyright (C) 2021, Intel Corporation. All rights reserved.",
                 &copyright
             );
         }

--- a/src/xed-c2rust.rs
+++ b/src/xed-c2rust.rs
@@ -82,7 +82,7 @@ pub unsafe extern "C" fn xed_operand_imm(mut p: *const xed_operand_t) -> uint32_
 #[inline]
 pub unsafe extern "C" fn xed_operand_is_register(mut name: xed_operand_enum_t) -> xed_uint_t {
     return (name as libc::c_uint >= XED_OPERAND_REG0 as libc::c_int as libc::c_uint
-        && name as libc::c_uint <= XED_OPERAND_REG8 as libc::c_int as libc::c_uint)
+        && name as libc::c_uint <= XED_OPERAND_REG9 as libc::c_int as libc::c_uint)
         as libc::c_int as xed_uint_t;
 }
 #[inline]
@@ -153,6 +153,19 @@ pub unsafe extern "C" fn xed3_operand_set_hint(
     mut opval: xed_bits_t,
 ) {
     (*d)._operands.hint = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_encode_force(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.encode_force as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_encode_force(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.encode_force = opval as uint8_t;
 }
 #[inline]
 pub unsafe extern "C" fn xed3_operand_get_lock(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
@@ -534,6 +547,19 @@ pub unsafe extern "C" fn xed3_operand_set_mode_first_prefix(
     (*d)._operands.mode_first_prefix = opval as uint8_t;
 }
 #[inline]
+pub unsafe extern "C" fn xed3_operand_get_mode_short_ud0(
+    mut d: *const xed_decoded_inst_t,
+) -> xed_bits_t {
+    return (*d)._operands.mode_short_ud0 as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_mode_short_ud0(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.mode_short_ud0 = opval as uint8_t;
+}
+#[inline]
 pub unsafe extern "C" fn xed3_operand_get_imm0(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
     return (*d)._operands.imm0 as xed_bits_t;
 }
@@ -689,15 +715,15 @@ pub unsafe extern "C" fn xed3_operand_set_scale(
     (*d)._operands.scale = opval as uint8_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_get_sib(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.sib as xed_bits_t;
+pub unsafe extern "C" fn xed3_operand_get_need_sib(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.need_sib as xed_bits_t;
 }
 #[inline]
-pub unsafe extern "C" fn xed3_operand_set_sib(
+pub unsafe extern "C" fn xed3_operand_set_need_sib(
     mut d: *mut xed_decoded_inst_t,
     mut opval: xed_bits_t,
 ) {
-    (*d)._operands.sib = opval as uint8_t;
+    (*d)._operands.need_sib = opval as uint8_t;
 }
 #[inline]
 pub unsafe extern "C" fn xed3_operand_get_sibscale(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
@@ -922,6 +948,17 @@ pub unsafe extern "C" fn xed3_operand_set_reg8(
     (*d)._operands.reg8 = opval as uint16_t;
 }
 #[inline]
+pub unsafe extern "C" fn xed3_operand_get_reg9(mut d: *const xed_decoded_inst_t) -> xed_reg_enum_t {
+    return (*d)._operands.reg9 as xed_reg_enum_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_reg9(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_reg_enum_t,
+) {
+    (*d)._operands.reg9 = opval as uint16_t;
+}
+#[inline]
 pub unsafe extern "C" fn xed3_operand_get_outreg(
     mut d: *const xed_decoded_inst_t,
 ) -> xed_reg_enum_t {
@@ -1020,17 +1057,6 @@ pub unsafe extern "C" fn xed3_operand_set_out_of_bytes(
     mut opval: xed_bits_t,
 ) {
     (*d)._operands.out_of_bytes = opval as uint8_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_get_amd3dnow(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
-    return (*d)._operands.amd3dnow as xed_bits_t;
-}
-#[inline]
-pub unsafe extern "C" fn xed3_operand_set_amd3dnow(
-    mut d: *mut xed_decoded_inst_t,
-    mut opval: xed_bits_t,
-) {
-    (*d)._operands.amd3dnow = opval as uint8_t;
 }
 #[inline]
 pub unsafe extern "C" fn xed3_operand_get_first_f2f3(
@@ -1306,6 +1332,17 @@ pub unsafe extern "C" fn xed3_operand_set_dummy(
     mut opval: xed_bits_t,
 ) {
     (*d)._operands.dummy = opval as uint8_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_get_amd3dnow(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
+    return (*d)._operands.amd3dnow as xed_bits_t;
+}
+#[inline]
+pub unsafe extern "C" fn xed3_operand_set_amd3dnow(
+    mut d: *mut xed_decoded_inst_t,
+    mut opval: xed_bits_t,
+) {
+    (*d)._operands.amd3dnow = opval as uint8_t;
 }
 #[inline]
 pub unsafe extern "C" fn xed3_operand_get_mpxmode(mut d: *const xed_decoded_inst_t) -> xed_bits_t {
@@ -1675,7 +1712,7 @@ pub unsafe extern "C" fn xed_relbr(
 ) -> xed_encoder_operand_t {
     let mut o: xed_encoder_operand_t = xed_encoder_operand_t {
         type_: XED_ENCODER_OPERAND_TYPE_INVALID,
-        u: C2RustUnnamed_6 {
+        u: C2RustUnnamed_7 {
             reg: XED_REG_INVALID,
         },
         width_bits: 0,
@@ -1692,7 +1729,7 @@ pub unsafe extern "C" fn xed_ptr(
 ) -> xed_encoder_operand_t {
     let mut o: xed_encoder_operand_t = xed_encoder_operand_t {
         type_: XED_ENCODER_OPERAND_TYPE_INVALID,
-        u: C2RustUnnamed_6 {
+        u: C2RustUnnamed_7 {
             reg: XED_REG_INVALID,
         },
         width_bits: 0,
@@ -1706,7 +1743,7 @@ pub unsafe extern "C" fn xed_ptr(
 pub unsafe extern "C" fn xed_reg(mut reg: xed_reg_enum_t) -> xed_encoder_operand_t {
     let mut o: xed_encoder_operand_t = xed_encoder_operand_t {
         type_: XED_ENCODER_OPERAND_TYPE_INVALID,
-        u: C2RustUnnamed_6 {
+        u: C2RustUnnamed_7 {
             reg: XED_REG_INVALID,
         },
         width_bits: 0,
@@ -1723,7 +1760,7 @@ pub unsafe extern "C" fn xed_imm0(
 ) -> xed_encoder_operand_t {
     let mut o: xed_encoder_operand_t = xed_encoder_operand_t {
         type_: XED_ENCODER_OPERAND_TYPE_INVALID,
-        u: C2RustUnnamed_6 {
+        u: C2RustUnnamed_7 {
             reg: XED_REG_INVALID,
         },
         width_bits: 0,
@@ -1740,7 +1777,7 @@ pub unsafe extern "C" fn xed_simm0(
 ) -> xed_encoder_operand_t {
     let mut o: xed_encoder_operand_t = xed_encoder_operand_t {
         type_: XED_ENCODER_OPERAND_TYPE_INVALID,
-        u: C2RustUnnamed_6 {
+        u: C2RustUnnamed_7 {
             reg: XED_REG_INVALID,
         },
         width_bits: 0,
@@ -1754,7 +1791,7 @@ pub unsafe extern "C" fn xed_simm0(
 pub unsafe extern "C" fn xed_imm1(mut v: uint8_t) -> xed_encoder_operand_t {
     let mut o: xed_encoder_operand_t = xed_encoder_operand_t {
         type_: XED_ENCODER_OPERAND_TYPE_INVALID,
-        u: C2RustUnnamed_6 {
+        u: C2RustUnnamed_7 {
             reg: XED_REG_INVALID,
         },
         width_bits: 0,
@@ -1771,7 +1808,7 @@ pub unsafe extern "C" fn xed_other(
 ) -> xed_encoder_operand_t {
     let mut o: xed_encoder_operand_t = xed_encoder_operand_t {
         type_: XED_ENCODER_OPERAND_TYPE_INVALID,
-        u: C2RustUnnamed_6 {
+        u: C2RustUnnamed_7 {
             reg: XED_REG_INVALID,
         },
         width_bits: 0,
@@ -1786,11 +1823,12 @@ pub unsafe extern "C" fn xed_other(
 pub unsafe extern "C" fn xed_seg0(mut seg0: xed_reg_enum_t) -> xed_encoder_operand_t {
     let mut o: xed_encoder_operand_t = xed_encoder_operand_t {
         type_: XED_ENCODER_OPERAND_TYPE_INVALID,
-        u: C2RustUnnamed_6 {
+        u: C2RustUnnamed_7 {
             reg: XED_REG_INVALID,
         },
         width_bits: 0,
     };
+    o.width_bits = 0 as libc::c_int as uint32_t;
     o.type_ = XED_ENCODER_OPERAND_TYPE_SEG0;
     o.u.reg = seg0;
     return o;
@@ -1799,11 +1837,12 @@ pub unsafe extern "C" fn xed_seg0(mut seg0: xed_reg_enum_t) -> xed_encoder_opera
 pub unsafe extern "C" fn xed_seg1(mut seg1: xed_reg_enum_t) -> xed_encoder_operand_t {
     let mut o: xed_encoder_operand_t = xed_encoder_operand_t {
         type_: XED_ENCODER_OPERAND_TYPE_INVALID,
-        u: C2RustUnnamed_6 {
+        u: C2RustUnnamed_7 {
             reg: XED_REG_INVALID,
         },
         width_bits: 0,
     };
+    o.width_bits = 0 as libc::c_int as uint32_t;
     o.type_ = XED_ENCODER_OPERAND_TYPE_SEG1;
     o.u.reg = seg1;
     return o;
@@ -1815,7 +1854,7 @@ pub unsafe extern "C" fn xed_mem_b(
 ) -> xed_encoder_operand_t {
     let mut o: xed_encoder_operand_t = xed_encoder_operand_t {
         type_: XED_ENCODER_OPERAND_TYPE_INVALID,
-        u: C2RustUnnamed_6 {
+        u: C2RustUnnamed_7 {
             reg: XED_REG_INVALID,
         },
         width_bits: 0,
@@ -1838,7 +1877,7 @@ pub unsafe extern "C" fn xed_mem_bd(
 ) -> xed_encoder_operand_t {
     let mut o: xed_encoder_operand_t = xed_encoder_operand_t {
         type_: XED_ENCODER_OPERAND_TYPE_INVALID,
-        u: C2RustUnnamed_6 {
+        u: C2RustUnnamed_7 {
             reg: XED_REG_INVALID,
         },
         width_bits: 0,
@@ -1862,7 +1901,7 @@ pub unsafe extern "C" fn xed_mem_bisd(
 ) -> xed_encoder_operand_t {
     let mut o: xed_encoder_operand_t = xed_encoder_operand_t {
         type_: XED_ENCODER_OPERAND_TYPE_INVALID,
-        u: C2RustUnnamed_6 {
+        u: C2RustUnnamed_7 {
             reg: XED_REG_INVALID,
         },
         width_bits: 0,
@@ -1884,7 +1923,7 @@ pub unsafe extern "C" fn xed_mem_gb(
 ) -> xed_encoder_operand_t {
     let mut o: xed_encoder_operand_t = xed_encoder_operand_t {
         type_: XED_ENCODER_OPERAND_TYPE_INVALID,
-        u: C2RustUnnamed_6 {
+        u: C2RustUnnamed_7 {
             reg: XED_REG_INVALID,
         },
         width_bits: 0,
@@ -1908,7 +1947,7 @@ pub unsafe extern "C" fn xed_mem_gbd(
 ) -> xed_encoder_operand_t {
     let mut o: xed_encoder_operand_t = xed_encoder_operand_t {
         type_: XED_ENCODER_OPERAND_TYPE_INVALID,
-        u: C2RustUnnamed_6 {
+        u: C2RustUnnamed_7 {
             reg: XED_REG_INVALID,
         },
         width_bits: 0,
@@ -1930,7 +1969,7 @@ pub unsafe extern "C" fn xed_mem_gd(
 ) -> xed_encoder_operand_t {
     let mut o: xed_encoder_operand_t = xed_encoder_operand_t {
         type_: XED_ENCODER_OPERAND_TYPE_INVALID,
-        u: C2RustUnnamed_6 {
+        u: C2RustUnnamed_7 {
             reg: XED_REG_INVALID,
         },
         width_bits: 0,
@@ -1955,7 +1994,7 @@ pub unsafe extern "C" fn xed_mem_gbisd(
 ) -> xed_encoder_operand_t {
     let mut o: xed_encoder_operand_t = xed_encoder_operand_t {
         type_: XED_ENCODER_OPERAND_TYPE_INVALID,
-        u: C2RustUnnamed_6 {
+        u: C2RustUnnamed_7 {
             reg: XED_REG_INVALID,
         },
         width_bits: 0,

--- a/tests/c2rust-miscompilation.rs
+++ b/tests/c2rust-miscompilation.rs
@@ -1,0 +1,29 @@
+use xed_sys::*;
+
+// c2rust seems to miscompile this recently. This test ensures that
+// we're doing the right thing.
+#[test]
+fn xed_state_get_address_width_miscompilation() {
+    fn test_val(mmode: xed_machine_mode_enum_t) -> xed_address_width_enum_t {
+        unsafe {
+            let mut state = std::mem::zeroed();
+            xed_state_init2(&mut state, mmode, XED_ADDRESS_WIDTH_64b);
+
+            xed_state_get_address_width(&mut state)
+        }
+    }
+
+    assert_eq!(test_val(XED_MACHINE_MODE_LONG_64), XED_ADDRESS_WIDTH_64b);
+    assert_eq!(test_val(XED_MACHINE_MODE_REAL_16), XED_ADDRESS_WIDTH_32b);
+    assert_eq!(test_val(XED_MACHINE_MODE_REAL_32), XED_ADDRESS_WIDTH_32b);
+    assert_eq!(test_val(XED_MACHINE_MODE_LEGACY_32), XED_ADDRESS_WIDTH_32b);
+    assert_eq!(test_val(XED_MACHINE_MODE_LEGACY_16), XED_ADDRESS_WIDTH_16b);
+    assert_eq!(
+        test_val(XED_MACHINE_MODE_LONG_COMPAT_32),
+        XED_ADDRESS_WIDTH_32b
+    );
+    assert_eq!(
+        test_val(XED_MACHINE_MODE_LONG_COMPAT_16),
+        XED_ADDRESS_WIDTH_16b
+    );
+}

--- a/tests/functions-exist.rs
+++ b/tests/functions-exist.rs
@@ -4,6 +4,6 @@ use xed_sys::*;
 fn functions_exist() {
     unsafe {
         // Just ensuring that this compiles
-        let _ = xed_isa_set_is_valid_for_chip(XED_ISA_SET_AES, XED_CHIP_AMD);
+        let _ = xed_isa_set_is_valid_for_chip(XED_ISA_SET_AES, XED_CHIP_AMD_ZEN);
     }
 }


### PR DESCRIPTION
This doesn't seem to be backwards compatible so there will need to be a version bump after this.

## Details
- Update submodules to the tip of the main branch for both `xed` and `mbuild`. This includes the updates to xed that
  Closes #38
- Fix clippy warnings that have occurred since there haven't been any updates in a while
- Update the generated inline methods to cover the new version of xed
- Any fixes to the generation script needed to get things working