### PR TITLE
Update version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xed-sys"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Phantomical", "Agustin Godnic"]
 license = "Apache-2.0"
 description = "Rust FFI bindings for Intel XED."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,18 +11,6 @@ extern crate core;
 
 pub use crate::_detail::{c2rust::*, xed_interface_inner::*};
 
-// Note: Remove this when v0.4 rolls around
-#[deprecated(since = "0.3.0", note = "All exports are now in the crate root")]
-pub mod xed_interface {
-    pub use crate::*;
-}
-
-// Note: Remove this when v0.4 rolls around
-#[deprecated(since = "0.3.0", note = "All exports are now in the crate root")]
-pub mod xed_version {
-    pub use crate::{xed_get_copyright, xed_get_version};
-}
-
 // This module shouldn't conflict with any of the stuff exported
 // in the root.
 mod _detail {


### PR DESCRIPTION
Updating to the newest version of XED is backwards-incompatible so we need to update the version to 0.4

Release checklist:
- [x] Update version in Cargo.toml (this PR)
- [ ] Write up release post for v0.4.0
- [ ] Publish on crates.io
- [x] Remove deprecated namespaces since this is the next major version bump