### PR TITLE
Avoid building dependabot branches on push

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,11 @@
 
-on: [push, pull_request]
+on:
+  # Dependabot branches are already built by the pull-request flow since
+  # dependabot will always open a corresponding PR.
+  push:
+    branches-ignore:
+      - dependabot/**
+  pull_request:
 
 name: ci-linux
 


### PR DESCRIPTION
These are already built by the pull-request flow, there is no point in building them again on push.