### PR TITLE
Update badges to match current CI setup

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ on:
       - dependabot/**
   pull_request:
 
-name: ci-linux
+name: ci
 
 jobs:
   build_and_test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,6 @@ keywords = ["xed", "intel", "x86", "x86_64"]
 categories = ["encoding", "external-ffi-bindings", "hardware-support", "parsing", "no_std"]
 rust-version = "1.64"
 
-[badges]
-appveyor  = { repository = "rust-xed/xed-sys" }
-travis-ci = { repository = "rust-xed/xed-sys" }
-
 [features]
 # Generate bindings with bindgen at build-time instead of using the
 # pregenerated bindings.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build Status](https://travis-ci.com/Phantomical/xed-sys.svg?branch=master)](https://travis-ci.com/Phantomical/xed-sys)
-[![Build status](https://ci.appveyor.com/api/projects/status/u6krc5mee7sdjn7a/branch/master?svg=true)](https://ci.appveyor.com/project/Phantomical/xed-sys/branch/master)
-[![Crates.io](https://img.shields.io/crates/v/xed-sys.svg)](https://crates.io/crates/xed-sys)
+[![Build Status](https://github.com/rust-xed/xed-sys/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/rust-xed/xed-sys/actions/workflows/build-and-test.yml)
+[![docs.rs](https://img.shields.io/docsrs/xed-sys)](https://docs.rs/xed-sys)
+[![crates.io](https://img.shields.io/crates/v/xed-sys.svg)](https://crates.io/crates/xed-sys)
 
 # xed-sys
 Rust FFI bindings for [Intel XED](https://intelxed.github.io/).


### PR DESCRIPTION
We don't use any of appveyor or travis CI anymore so having badges pointing to them in the readme isn't very useful. This updates the badges to point to github actions instead.