### PR TITLE
Fix cross-compilation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -51,6 +51,7 @@ fn build_xed() {
     println!("cargo:rerun-if-changed=xed/VERSION");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed-env=PROFILE");
+    println!("cargo:rerun-if-changed-env=CROSS_TOOLCHAIN_PREFIX");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("Failed to read OUT_DIR"));
     let cwd = env::current_dir().expect("Failed to get CWD");
@@ -93,6 +94,10 @@ fn build_xed() {
                 .architecture
         ))
         .arg(format!("--install-dir={}", install_dir.display()));
+
+    if let Ok(toolchain) = env::var("CROSS_TOOLCHAIN_PREFIX") {
+        cmd.arg(format!("--toolchain={toolchain}"));
+    }
 
     if profile == "release" {
         cmd.arg("--opt=3");


### PR DESCRIPTION
Hi!

I have been running into some compilation problems when cross-compiling `xed-sys` for other architectures with [`cross`](https://github.com/cross-rs/cross). I have fixed this issue, and was hoping you would be willing to accept the patch.

When cross-compiling, the `--toolchain` argument needs to be passed to XED's `mfile.py`. This ensures that XED builds its object files with the correct toolchain binaries. When compiling with `cross build`, the CROSS_TOOLCHAIN_PREFIX environment variable is automatically provided. This patch ensures that the environment variable is passed to `mfile.py` through the `--toolchain` argument.

I am happy to make additional changes if needed.